### PR TITLE
make svg optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,11 @@ flake8-svg-badge
 
 Svg badge that shows % of problem-free code
 
+Usage
+-----
+.. code-block:: bash
+    
+    flake8 --format svg --image flake8.svg
 
 Features
 --------

--- a/flake8_svg_badge/reporter.py
+++ b/flake8_svg_badge/reporter.py
@@ -1,3 +1,4 @@
+from argparse import ArgumentParser, SUPPRESS
 import sys
 from functools import reduce
 from textwrap import dedent
@@ -53,6 +54,8 @@ def find_color(total):
 
 
 class ReportSVGBadge(base.BaseFormatter):
+    
+    name = "flake8-svg-badge"
 
     def __init__(self, options):
         super().__init__(options)
@@ -63,8 +66,9 @@ class ReportSVGBadge(base.BaseFormatter):
     def after_init(self):
         super().after_init()
 
-        if not self.options.image:
-            raise Exception('--image must be given to generate svg badge')
+        if self.options.format == 'svg' and not self.options.image:
+            parser = ArgumentParser(usage=SUPPRESS)
+            parser.error('--image must be given to generate svg badge')
 
     def beginning(self, filename):
         super().beginning(filename)

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -13,8 +13,8 @@ from flake8_svg_badge.reporter import ReportSVGBadge
 
 def test_exception_on_no_image_path():
 
-    with pytest.raises(Exception):
-        rp = ReportSVGBadge(Values({'output_file': None}))
+    with pytest.raises(SystemExit):
+        rp = ReportSVGBadge(Values({'format': 'svg', 'image': None, 'output_file': None}))
 
 
 def test_parse_file_no_errors():
@@ -24,7 +24,7 @@ def test_parse_file_no_errors():
     cwd = os.getcwd()
     os.chdir(target_path)
     try:
-        rp = ReportSVGBadge(Values({'output_file': None, 'image': '123.svg'}))
+        rp = ReportSVGBadge(Values({'output_file': None, 'image': '123.svg', 'format': 'svg'}))
 
         with open('lala.py', 'w') as f:
             f.write('print(123)\n')
@@ -58,7 +58,7 @@ def test_parse_file_one_error():
     cwd = os.getcwd()
     os.chdir(target_path)
     try:
-        rp = ReportSVGBadge(Values({'output_file': None, 'image': '123.svg'}))
+        rp = ReportSVGBadge(Values({'output_file': None, 'image': '123.svg', 'format': 'svg'}))
 
         with open('lala.py', 'w') as f:
             f.write('print(123)\n')


### PR DESCRIPTION
- Only requires --image arg if --format arg is set to 'svg'
- Uses Argparse's parser.error instead of raising Exception
- Added Class name as it was failing without it
- Added usage example to readme
- Updated the tests to include the --format arg in Values